### PR TITLE
Fix missing metric on retrieval failure

### DIFF
--- a/kafka_connect_exporter.go
+++ b/kafka_connect_exporter.go
@@ -72,6 +72,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		Timeout: 3 * time.Second,
 	}
 	e.up.Set(0)
+	ch <- e.up
 
 	response, err := client.Get(e.URI + "/connectors")
 	if err != nil {

--- a/kafka_connect_exporter.go
+++ b/kafka_connect_exporter.go
@@ -72,17 +72,18 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		Timeout: 3 * time.Second,
 	}
 	e.up.Set(0)
-	ch <- e.up
 
 	response, err := client.Get(e.URI + "/connectors")
 	if err != nil {
 		log.Errorf("Can't scrape kafka connect: %v", err)
+		ch <- e.up
 		return
 	}
 	defer func() {
 		err = response.Body.Close()
 		if err != nil {
 			log.Errorf("Can't close connection to kafka connect: %v", err)
+			ch <- e.up
 			return
 		}
 	}()
@@ -90,12 +91,14 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	output, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Errorf("Can't scrape kafka connect: %v", err)
+		ch <- e.up
 		return
 	}
 
 	var connectorsList connectors
 	if err := json.Unmarshal(output, &connectorsList); err != nil {
 		log.Errorf("Can't scrape kafka connect: %v", err)
+		ch <- e.up
 		return
 	}
 


### PR DESCRIPTION
The exporter was missing the gauge `kafka_connect_up` when failing to connect to the specified URI